### PR TITLE
role:owner doesn't work, just list the owner instead

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,4 +2,4 @@
 
 ## How to add members to a team
 
-Before maintainers of projects can add members to teams the members must be added to the good-labs organization by one of the owners of the organization. You can see a list of owners at https://github.com/orgs/good-labs/people?query=role%3Aowner and then click on their usernames to find contact information for them. Ask them to add the future team member to the organization.
+Before maintainers of projects can add members to teams the members must be added to the good-labs organization by the owner of the organization, [@vsoch](https://github.com/vsoch).


### PR DESCRIPTION
Unfortunately, if you click the "role:owner" link... 

<img width="1523" alt="Screen Shot 2019-05-25 at 3 47 55 PM" src="https://user-images.githubusercontent.com/21006/58374032-f47de980-7f04-11e9-9161-14c836a45a87.png">

... you are not given an accurate list of who the owners are. Check this out:

<img width="1523" alt="Screen Shot 2019-05-25 at 3 48 00 PM" src="https://user-images.githubusercontent.com/21006/58374033-f47de980-7f04-11e9-9cf5-d3df7223497e.png">

I tested this on a couple other organizations ( https://github.com/orgs/IQSS/people?utf8=%E2%9C%93&query=role%3Aowner for example) and I can tell you that it's completely inaccurate. So it's safer to simply enumerate the owners. That's what this pull request is about. 😄 